### PR TITLE
Endpoint to check for particular upstream host on lb

### DIFF
--- a/src/main/scala/org/constellation/NetworkLoadbalancer.scala
+++ b/src/main/scala/org/constellation/NetworkLoadbalancer.scala
@@ -35,7 +35,7 @@ object NetworkLoadbalancer extends IOApp {
       )
       .flatMap {
         case Some(context) => Right(context)
-        case _             => Left(logger.error("The list of inital hosts is empty, provide via config or commandline"))
+        case _             => Left(logger.error("The list of initial hosts is empty, provide via config or commandline"))
       }
       .fold(
         _.map(_ => ExitCode.Error), {

--- a/src/main/scala/org/constellation/node/NodeApi.scala
+++ b/src/main/scala/org/constellation/node/NodeApi.scala
@@ -24,7 +24,8 @@ class RestNodeApi(node: Addr, identity: Option[BasicCredentials])(implicit http:
 
   private val getInfoRequest = Request[IO](
     uri = baseUri.withPath("/cluster/info"),
-    headers = identity.map(creds => Headers.of(Authorization(creds))).getOrElse(Headers.empty))
+    headers = identity.map(creds => Headers.of(Authorization(creds))).getOrElse(Headers.empty)
+  )
 
   def getInfo: IO[List[Info]] =
     http.expect(getInfoRequest)(jsonOf[IO, List[Info]])

--- a/src/main/scala/org/constellation/primitives/node/NodeState.scala
+++ b/src/main/scala/org/constellation/primitives/node/NodeState.scala
@@ -3,7 +3,7 @@ package org.constellation.primitives.node
 object NodeState extends Enumeration {
   type State = Value
 
-  val PendingDownload, DownloadInProgress, DownloadCompleteAwaitingFinalSync, Ready, Leaving, Offline,
-      SnapshotCreation, ReadyForDownload = Value
+  val PendingDownload, DownloadInProgress, DownloadCompleteAwaitingFinalSync, Ready, Leaving, Offline, SnapshotCreation,
+      ReadyForDownload = Value
 
 }


### PR DESCRIPTION
I would like to add a simple endpoint that will let us check via simple curl request if the host is registered in the lb. This endpoint is more lightweight than fetching whole cluster info and will let node operators run simple monitoring service on a single url to check for their node presence in the cluster.