### PR TITLE
Return 400 on /health when LB has zero hosts

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.3
+sbt.version = 1.8.0

--- a/src/main/scala/org/constellation/http/Loadbalancer.scala
+++ b/src/main/scala/org/constellation/http/Loadbalancer.scala
@@ -78,8 +78,13 @@ class Loadbalancer(port: Int = 9000, host: String = "localhost", retryAfterMinut
     case GET -> Root / "health" =>
       upstream.get
         .map(_.size)
-        .flatTap(size => logger.info(s"I understand Im healthy, my upstream size is now $size"))
-        .flatMap(size => Ok(s"$size"))
+        .flatTap(size => logger.info(s"Health check: my upstream size is $size"))
+        .flatMap { size =>
+          size match {
+            case 0 => InternalServerError()
+            case _ => Ok(s"$size")
+          }
+        }
     case GET -> Root / "health" / addrStr =>
       Addr
         .unapply(addrStr)


### PR DESCRIPTION
The current health check endpoint always returns a 200 response, even if there are no known hosts. This change returns a 400 response when no hosts are found so that the health checks can be properly responded to. Repeated health check failures will now cause ECS to trigger a new task to launch and kick off the node discovery process again. 

Tested locally. 